### PR TITLE
Typecast exception of Null value handled

### DIFF
--- a/biometric-compat/src/main/java/com/niravtukadiya/compat/biometric/BiometricCompatV23.kt
+++ b/biometric-compat/src/main/java/com/niravtukadiya/compat/biometric/BiometricCompatV23.kt
@@ -155,9 +155,14 @@ open class BiometricCompatV23 {
 
         try {
             keyStore.load(null)
-            val key = keyStore.getKey(KEY_NAME, null) as SecretKey
-            cipher.init(Cipher.ENCRYPT_MODE, key)
-            return true
+            val key = keyStore.getKey(KEY_NAME, null)
+            return if (key != null) {
+                cipher.init(Cipher.ENCRYPT_MODE, key as SecretKey)
+                true
+            } else {
+                false
+            }
+
 
         } catch (e: KeyPermanentlyInvalidatedException) {
             return false
@@ -173,6 +178,8 @@ open class BiometricCompatV23 {
             throw RuntimeException("Failed to init Cipher", e)
         } catch (e: InvalidKeyException) {
             throw RuntimeException("Failed to init Cipher", e)
+        } catch (e: TypeCastException) {
+            return false
         }
     }
 


### PR DESCRIPTION
If the keystore key is null, then typecasting it to secret key will crash the app. Handled now.
Also added additional check to make the typecasting safe.